### PR TITLE
Use writeShellScriptBin to generate flash script

### DIFF
--- a/nixcaps.nix
+++ b/nixcaps.nix
@@ -2,7 +2,8 @@
   qmk,
   fetchFromGitHub,
   stdenv,
-  lib,
+  writeShellScriptBin,
+  symlinkJoin,
 }:
 rec {
   qmk_firmware = fetchFromGitHub {
@@ -27,36 +28,37 @@ rec {
       keyboardVariant = if builtins.isNull variant then "${keyboard}" else "${keyboard}/${variant}";
       keymapName = "nixcaps";
       keymapDir = "${keyboardDir}/keymaps/${keymapName}";
-    in
-    stdenv.mkDerivation {
-      name = "nixcaps-compile";
-      src = qmk_firmware;
-      buildInputs = [ qmk ];
-      postPatch = ''
-        mkdir -p ${keymapDir}
-        cp -r ${src}/* ${keymapDir}/
-      '';
-      buildPhase = ''
-        qmk compile \
-          --env SKIP_GIT=true \
-          --env BUILD_DIR=${buildDir} \
-          --env TARGET=${target} \
-          --keyboard ${keyboardVariant} \
-          --keymap ${keymapName}
-      '';
-      installPhase = ''
-        mkdir -p $out/bin
-        cp ${buildDir}/*.{hex,bin,elf,dfu,uf2,eep} $out/bin
+      buildDrv = stdenv.mkDerivation {
+        name = "nixcaps-compile";
+        src = qmk_firmware;
+        buildInputs = [ qmk ];
+        postPatch = ''
+            mkdir -p ${keymapDir}
+            cp -r ${src}/* ${keymapDir}/
+        '';
+        buildPhase = ''
+            qmk compile \
+             --env SKIP_GIT=true \
+             --env BUILD_DIR=${buildDir} \
+             --env TARGET=${target} \
+             --keyboard ${keyboardVariant} \
+             --keymap ${keymapName}
+        '';
+        installPhase = ''
+            mkdir -p $out/bin
+            cp ${buildDir}/*.{hex,bin,elf,dfu,uf2,eep} $out/bin
+        '';
+        dontFixup = true;
+      };
 
-        ${lib.optionalString (!builtins.isNull flash) ''
-          cat > $out/bin/flash <<EOF
-          #!/bin/sh
-          set -e
-          ${flash (placeholder "out" + "/bin/${target}")}
-          EOF
-          chmod +x $out/bin/flash
-        ''}
-      '';
-      dontFixup = true;
-    };
+      flashText = flash "${buildDrv}/bin/${target}";
+      flashDrv = (writeShellScriptBin "flash" flashText).overrideAttrs (_: { name = "nixcaps-flash-script"; });
+    in
+      symlinkJoin {
+        name = "nixcaps-output";
+        paths = [
+          buildDrv
+          flashDrv
+        ];
+      };
 }

--- a/nixcaps.nix
+++ b/nixcaps.nix
@@ -4,6 +4,7 @@
   stdenv,
   writeShellScriptBin,
   symlinkJoin,
+  lib,
 }:
 rec {
   qmk_firmware = fetchFromGitHub {
@@ -56,9 +57,9 @@ rec {
     in
       symlinkJoin {
         name = "nixcaps-output";
-        paths = [
+        paths = lib.flatten [
           buildDrv
-          flashDrv
+          (lib.optional (!isNull flash) flashDrv)
         ];
       };
 }


### PR DESCRIPTION
Previously, we `cat`d the contents of `flash` into a file during the builder's installPhase. That lead to variables inside flash being substituted at compile time. Moving the flash script to another derivation, allows us to leverage `writeShellScriptBin`and not bother maintaining the script instantiation code.

Another benefit to separating them into two derivations is preventing firmware rebuilds due to changes on the flashing script.

Closes #2 