### PR TITLE
Set meta.mainProgram on the output derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ flash  # flasher script
 fw.elf # firmware files
 fw.hex # ...
 $ # flash the compiled firmware
-$ sudo ./result/bin/flash
+$ sudo ./result/bin/flash # or nix run
 Flashing /nix/store/b5jnf80...-nixcaps-compile/bin/fw.hex ...
 Teensy Loader, Command Line, Version 2.3
 Read "/nix/store/b5jnf80...-nixcaps-compile/bin/fw.hex": 28074 bytes, 87.0% usage

--- a/nixcaps.nix
+++ b/nixcaps.nix
@@ -63,5 +63,6 @@ rec {
         buildDrv
         (lib.optional (!isNull flash) flashDrv)
       ];
+      meta.mainProgram = "flash";
     };
 }


### PR DESCRIPTION
Hello!

I don't know how to make the `nix run` line fit better than this on the readme.