### PR TITLE
fix(nix): Fix usage of patchShebangs

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -18,15 +18,13 @@ in
 stdenv.mkDerivation {
   name = "${qmk_args.keymapName}-firmware";
   src = qmk_firmware;
-  buildInputs = [
-    qmk
-    python313
-  ];
+  nativeBuildInputs = [ python313 ];
+  buildInputs = [ qmk ];
 
   postPatch = ''
     mkdir -p ${qmk_args.keymapDir}
     cp -r ${src}/* ${qmk_args.keymapDir}/
-    patchShebangs --host ${python313}/bin
+    patchShebangs util lib
   '';
 
   buildPhase = ''

--- a/nix/compiledb.nix
+++ b/nix/compiledb.nix
@@ -19,16 +19,16 @@ in
 stdenv.mkDerivation {
   name = "${qmk_args.keymapName}-compiledb";
   src = qmk_firmware;
+  nativeBuildInputs = [ python313 ];
   buildInputs = [
     qmk
     jq
-    python313
   ];
 
   postPatch = ''
     mkdir -p ${qmk_args.keymapDir}
     cp -r ${src}/* ${qmk_args.keymapDir}/
-    patchShebangs --host ${python313}/bin
+    patchShebangs util lib
   '';
 
   buildPhase = ''


### PR DESCRIPTION
Usage of `patchShebangs` was wrong. It worked when I tested it locally because macOS ships with `python3` by default in the global environment, but this fails in GitHub Actions, because `patchShebangs` was not actually doing its job.