### PR TITLE
Change "-default" keymap suffix to "-nixcaps"

### DIFF
--- a/nix/qmk-args.nix
+++ b/nix/qmk-args.nix
@@ -7,7 +7,7 @@
 let
   keyboardVariant = if variant == null then "${keyboard}" else "${keyboard}/${variant}";
   keyboardName = lib.last (lib.splitString "/" keyboard);
-  keymapName = "${keyboardName}-default";
+  keymapName = "${keyboardName}-nixcaps";
 in
 {
   inherit


### PR DESCRIPTION
Hi! Very cool rewrite yall did!
I wanted to rebinding a key on my keyboard today and took the opportunity to update nixcaps. When I was about to flash the firmware, I saw "<keyboard>-default" being built and got scared cause thought I was about to override my firmware with the actual default layout for my keyboard (whatever qmk says it is upstream) hahaha.
Changing this so people don't also get scared in the future.